### PR TITLE
chore: remove latest marks from future releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,3 @@ jobs:
           CR_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
         with:
           config: cr.yaml
-          mark_as_latest: false

--- a/cr.yaml
+++ b/cr.yaml
@@ -3,3 +3,4 @@
 sign: true
 # UID of the GPG key to use
 key: helm-signing@keptn.sh
+make-release-latest: false


### PR DESCRIPTION
### This PR
- removes the marking of future releases with "latest" since this is a monorepo and therefore there's multiple "latest" releases for the different charts