### PR TITLE
fix: fix imagePullSecrets rendering

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,4 +15,4 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1

--- a/charts/common/templates/_images.tpl
+++ b/charts/common/templates/_images.tpl
@@ -54,17 +54,10 @@ Return the proper Image Registry Secret Names evaluating values as templates
     {{- end -}}
   {{- end -}}
 
-  {{- if (not (empty $pullSecrets)) }}
+  {{- if (not (empty $pullSecrets)) -}}
 imagePullSecrets:
     {{- range $pullSecrets | uniq }}
   - name: {{ . }}
     {{- end }}
   {{- end }}
-{{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names
-*/}}
-{{- define "common.images.imagePullSecrets" -}}
-{{- include "common.images.renderPullSecrets" (dict "images" list "global" .Values.global) | default list| toJson | indent 1 -}}
 {{- end -}}


### PR DESCRIPTION
This fixes a small bug where rendering of image pull secrets had additional whitespace.
This also removes an unused helper function.